### PR TITLE
Info API: OrderFill fields

### DIFF
--- a/hyperliquid/info_test.go
+++ b/hyperliquid/info_test.go
@@ -11,6 +11,9 @@ func GetInfoAPI() *InfoAPI {
 		api.SetDebugActive()
 	}
 	TEST_ADDRESS := os.Getenv("TEST_ADDRESS")
+	if TEST_ADDRESS == "" {
+		panic("Set TEST_ADDRESS in .env file")
+	}
 	api.SetAccountAddress(TEST_ADDRESS)
 	return api
 }
@@ -60,6 +63,17 @@ func TestInfoAPI_GetAccountFills(t *testing.T) {
 	}
 	if len(*res) == 0 {
 		t.Errorf("GetAccountFills() len = %v, want > %v", res, 0)
+	}
+	res0 := (*res)[0]
+	t.Logf("res0 = %+v", res0)
+	if res0.Px == 0 {
+		t.Errorf("res0.Px = %v, want > %v", res0.Px, 0)
+	}
+	if res0.Sz == 0 {
+		t.Errorf("res0.Sz = %v, want > %v", res0.Sz, 0)
+	}
+	if res0.Fee == 0 {
+		t.Errorf("res0.Fee = %v, want > %v", res0.Fee, 0)
 	}
 	t.Logf("GetAccountFills() = %v", res)
 }

--- a/hyperliquid/info_types.go
+++ b/hyperliquid/info_types.go
@@ -91,18 +91,18 @@ type Meta struct {
 
 type OrderFill struct {
 	Cloid         string       `json:"cloid"`
-	ClosedPnl     string       `json:"closedPnl"`
+	ClosedPnl     float64      `json:"closedPnl,string"`
 	Coin          string       `json:"coin"`
 	Crossed       bool         `json:"crossed"`
 	Dir           string       `json:"dir"`
-	Fee           string       `json:"fee"`
+	Fee           float64      `json:"fee,string"`
 	FeeToken      string       `json:"feeToken"`
 	Hash          string       `json:"hash"`
 	Oid           int          `json:"oid"`
-	Px            string       `json:"px"`
+	Px            float64      `json:"px,string"`
 	Side          string       `json:"side"`
 	StartPosition string       `json:"startPosition"`
-	Sz            string       `json:"sz"`
+	Sz            float64      `json:"sz,string"`
 	Tid           int64        `json:"tid"`
 	Time          int64        `json:"time"`
 	Liquidation   *Liquidation `json:"liquidation"`


### PR DESCRIPTION
This pull request includes several changes to the `hyperliquid` package, focusing on improving error handling, enhancing test coverage, and updating data types for consistency. The most important changes include adding error checks, improving test logging, and converting string fields to float64 in the `OrderFill` struct.

Error handling improvements:

* [`hyperliquid/info_test.go`](diffhunk://#diff-9daee59269cac90ec7f5c8332f9c0804f61c3582174f26a632dc3dc0a2e2f3bcR14-R16): Added a check to ensure `TEST_ADDRESS` is set in the environment, and panic if it is not.

Test coverage enhancements:

* [`hyperliquid/info_test.go`](diffhunk://#diff-9daee59269cac90ec7f5c8332f9c0804f61c3582174f26a632dc3dc0a2e2f3bcR67-R77): Enhanced the `TestInfoAPI_GetAccountFills` function by adding detailed logging and additional checks for `Px`, `Sz`, and `Fee` fields in the response.

Data type consistency:

* [`hyperliquid/info_types.go`](diffhunk://#diff-a4b71b80818bbbddc16e8f808a0b74d1561355b01bc318c8db41d2c8baf39596L94-R105): Updated the `OrderFill` struct to convert `ClosedPnl`, `Fee`, `Px`, and `Sz` fields from strings to float64 for better numerical handling.