### PR TITLE
Add EIP712 order building method

### DIFF
--- a/hyperliquid/exchange_msg_builders_test.go
+++ b/hyperliquid/exchange_msg_builders_test.go
@@ -1,0 +1,42 @@
+package hyperliquid
+
+import (
+	"math"
+	"testing"
+)
+
+func GetEmptyExchangeAPI() *ExchangeAPI {
+	exchangeAPI := NewExchangeAPI(true)
+	if GLOBAL_DEBUG {
+		exchangeAPI.SetDebugActive()
+	}
+	return exchangeAPI
+}
+
+func TestExchangeAPI_BuildOrder(t *testing.T) {
+	exchangeAPI := GetEmptyExchangeAPI()
+	// input params
+	coin := "ETH"
+	size := 0.1
+	price := 2500.0
+
+	isBuy := IsBuy(size)
+	orderType := OrderType{
+		Limit: &LimitOrderType{
+			Tif: TifIoc,
+		},
+	}
+	orderRequest := OrderRequest{
+		Coin:       coin,
+		IsBuy:      isBuy,
+		Sz:         math.Abs(size),
+		LimitPx:    price,
+		OrderType:  orderType,
+		ReduceOnly: false,
+	}
+	res, err := exchangeAPI.BuildOrderEIP712(orderRequest, GroupingNa)
+	if err != nil {
+		t.Errorf("BuildOrder() error = %v", err)
+	}
+	t.Logf("BuildOrder() = %+v", res)
+}

--- a/hyperliquid/signature.go
+++ b/hyperliquid/signature.go
@@ -64,13 +64,7 @@ func NewSigner(manager *PKeyManager) Signer {
 }
 
 func (signer *Signer) Sign(request *SignRequest) (byte, [32]byte, [32]byte, error) {
-	typedData := apitypes.TypedData{
-		Domain:      request.GetDomain(),
-		Types:       request.GetTypes(),
-		PrimaryType: request.PrimaryType,
-		Message:     request.DTypeMsg,
-	}
-	return signer.signInternal(typedData)
+	return signer.signInternal(SignRequestToEIP712TypedData(request))
 }
 
 // signInternal signs the typed data and returns the signature in VRS format
@@ -87,6 +81,15 @@ func (signer *Signer) signInternal(message apitypes.TypedData) (byte, [32]byte, 
 		return 0, [32]byte{}, [32]byte{}, err
 	}
 	return SignatureToVRS(signature)
+}
+
+func SignRequestToEIP712TypedData(request *SignRequest) apitypes.TypedData {
+	return apitypes.TypedData{
+		Domain:      request.GetDomain(),
+		Types:       request.GetTypes(),
+		PrimaryType: request.PrimaryType,
+		Message:     request.DTypeMsg,
+	}
 }
 
 func SignatureToVRS(sig []byte) (byte, [32]byte, [32]byte, error) {


### PR DESCRIPTION
This pull request introduces new functionality and refactors existing code in the `hyperliquid` package to support building and signing EIP712 messages for orders. The most important changes include adding new methods for building and signing EIP712 messages, refactoring existing methods to use the new EIP712 message structure, and updating tests to cover the new functionality.

### New Functionality:

* [`hyperliquid/exchange_service.go`](diffhunk://#diff-4156bb8cb3316509d3cd1f5273e7c5692af648384a27cf96a69264bf551c808aR313-R333): Added `BuildBulkOrdersEIP712` and `BuildOrderEIP712` methods to build EIP712 messages for bulk and single orders respectively.
* [`hyperliquid/exchange_signing.go`](diffhunk://#diff-c3ee218d0b967dd2b9745cc1824788896d0ddb50b18fc91c5bb06727d85caea0L37-R49): Added `BuildEIP712Message` method to construct EIP712 messages for signing.

### Refactoring:

* [`hyperliquid/exchange_signing.go`](diffhunk://#diff-c3ee218d0b967dd2b9745cc1824788896d0ddb50b18fc91c5bb06727d85caea0L59-R67): Updated `SignL1Action` to use the new `BuildEIP712Message` method.
* [`hyperliquid/signature.go`](diffhunk://#diff-1245e54135a771e688d8a973f87d28fac2c821ab57de917d18faf552f15bf43bL67-R67): Refactored `Sign` method in `Signer` to use `SignRequestToEIP712TypedData` for converting `SignRequest` to `TypedData`.
* [`hyperliquid/signature.go`](diffhunk://#diff-1245e54135a771e688d8a973f87d28fac2c821ab57de917d18faf552f15bf43bR86-R94): Added `SignRequestToEIP712TypedData` function to convert `SignRequest` to `TypedData`.

### Testing:

* [`hyperliquid/exchange_msg_builders_test.go`](diffhunk://#diff-f365a34d75fb59abbc0aecd612fe52a50482e14bfd53cc5af277a0aa17f77748R1-R42): Added `TestExchangeAPI_BuildOrder` to test the `BuildOrderEIP712` method.