### PR TITLE
Exchange API: Added `Cloid` support, bulk modify orders

### DIFF
--- a/hyperliquid/convert.go
+++ b/hyperliquid/convert.go
@@ -33,6 +33,21 @@ func HexToBytes(addr string) []byte {
 		return b
 	}
 }
+func HexToInt(hexString string) (*big.Int, error) {
+	value := new(big.Int)
+	if len(hexString) > 1 && hexString[:2] == "0x" {
+		hexString = hexString[2:]
+	}
+	_, success := value.SetString(hexString, 16)
+	if !success {
+		return nil, fmt.Errorf("invalid hexadecimal string: %s", hexString)
+	}
+	return value, nil
+}
+
+func IntToHex(value *big.Int) string {
+	return "0x" + value.Text(16) 
+}
 
 func OrderWiresToOrderAction(orders []OrderWire, grouping Grouping) PlaceOrderAction {
 	return PlaceOrderAction{
@@ -51,6 +66,7 @@ func OrderRequestToWire(req OrderRequest, meta map[string]AssetInfo) OrderWire {
 		SizePx:     FloatToWire(req.Sz, &info.SzDecimals),
 		ReduceOnly: req.ReduceOnly,
 		OrderType:  OrderTypeToWire(req.OrderType),
+		Cloid:      req.Cloid,
 	}
 }
 func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo) ModifyOrderWire {
@@ -64,6 +80,7 @@ func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo)
 			SizePx:     FloatToWire(req.Sz, &info.SzDecimals),
 			ReduceOnly: req.ReduceOnly,
 			OrderType:  OrderTypeToWire(req.OrderType),
+			Cloid:      req.Cloid,
 		},
 	}
 }

--- a/hyperliquid/convert.go
+++ b/hyperliquid/convert.go
@@ -53,6 +53,20 @@ func OrderRequestToWire(req OrderRequest, meta map[string]AssetInfo) OrderWire {
 		OrderType:  OrderTypeToWire(req.OrderType),
 	}
 }
+func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo) ModifyOrderWire {
+	info := meta[req.Coin]
+	return ModifyOrderWire{
+		OrderId: req.OrderId,
+		Order: OrderWire{
+			Asset:      info.AssetId,
+			IsBuy:      req.IsBuy,
+			LimitPx:    FloatToWire(req.LimitPx, nil),
+			SizePx:     FloatToWire(req.Sz, &info.SzDecimals),
+			ReduceOnly: req.ReduceOnly,
+			OrderType:  OrderTypeToWire(req.OrderType),
+		},
+	}
+}
 
 func OrderTypeToWire(orderType OrderType) OrderTypeWire {
 	if orderType.Limit != nil {

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -154,7 +154,7 @@ type InnerCancelResponse struct {
 }
 
 type CancelResponseStatuses struct {
-	Statuses []string `json:"statuses"`
+    Statuses []StatusResponse `json:"statuses"`
 }
 
 type RestingStatus struct {

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -73,6 +73,29 @@ type OrderWire struct {
 	OrderType  OrderTypeWire `msgpack:"t" json:"t"`
 	Cloid      string        `msgpack:"c,omitempty" json:"c,omitempty"`
 }
+type ModifyResponse struct {
+	Status   string                  `json:"status"`
+	Response PlaceOrderInnerResponse `json:"response"`
+}
+type ModifyOrderWire struct {
+	OrderId int       `msgpack:"oid" json:"oid"`
+	Order   OrderWire `msgpack:"order" json:"order"`
+}
+type ModifyOrderAction struct {
+	Type     string            `msgpack:"type" json:"type"`
+	Modifies []ModifyOrderWire `msgpack:"modifies" json:"modifies"`
+}
+
+type ModifyOrderRequest struct {
+	OrderId    int       `json:"oid"`
+	Coin       string    `json:"coin"`
+	IsBuy      bool      `json:"is_buy"`
+	Sz         float64   `json:"sz"`
+	LimitPx    float64   `json:"limit_px"`
+	OrderType  OrderType `json:"order_type"`
+	ReduceOnly bool      `json:"reduce_only"`
+	Cloid      string    `json:"cloid,omitempty"`
+}
 
 type OrderTypeWire struct {
 	Limit   *LimitOrderType   `json:"limit,omitempty" msgpack:"limit,omitempty"`

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -26,6 +26,7 @@ type OrderRequest struct {
 	LimitPx    float64   `json:"limit_px"`
 	OrderType  OrderType `json:"order_type"`
 	ReduceOnly bool      `json:"reduce_only"`
+	Cloid      string    `json:"cloid,omitempty"`
 }
 
 type OrderType struct {
@@ -137,10 +138,18 @@ type CancelOidOrderAction struct {
 	Type    string          `msgpack:"type" json:"type"`
 	Cancels []CancelOidWire `msgpack:"cancels" json:"cancels"`
 }
+type CancelCloidOrderAction struct {
+	Type    string            `msgpack:"type" json:"type"`
+	Cancels []CancelCloidWire `msgpack:"cancels" json:"cancels"`
+}
 
 type CancelOidWire struct {
 	Asset int `msgpack:"a" json:"a"`
 	Oid   int `msgpack:"o" json:"o"`
+}
+type CancelCloidWire struct {
+	Asset int    `msgpack:"asset" json:"asset"`
+	Cloid string `msgpack:"cloid" json:"cloid"`
 }
 
 type CancelOrderResponse struct {


### PR DESCRIPTION
- Added bulk modify orders method  
- Added `Cloid` field to `OrderRequest` 
- Added bulk cancel by `Cloid` method
- Fixed json unmarshal error for error responses to bulk cancels by parsing `statuses` as `StatusResponse`