### PR TITLE
Exchange API: Added bulk modify orders

### DIFF
--- a/hyperliquid/convert.go
+++ b/hyperliquid/convert.go
@@ -53,6 +53,20 @@ func OrderRequestToWire(req OrderRequest, meta map[string]AssetInfo) OrderWire {
 		OrderType:  OrderTypeToWire(req.OrderType),
 	}
 }
+func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo) ModifyOrderWire {
+	info := meta[req.Coin]
+	return ModifyOrderWire{
+		OrderId: req.OrderId,
+		Order: OrderWire{
+			Asset:      info.AssetId,
+			IsBuy:      req.IsBuy,
+			LimitPx:    FloatToWire(req.LimitPx, nil),
+			SizePx:     FloatToWire(req.Sz, &info.SzDecimals),
+			ReduceOnly: req.ReduceOnly,
+			OrderType:  OrderTypeToWire(req.OrderType),
+		},
+	}
+}
 
 func OrderTypeToWire(orderType OrderType) OrderTypeWire {
 	if orderType.Limit != nil {

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -73,6 +73,29 @@ type OrderWire struct {
 	OrderType  OrderTypeWire `msgpack:"t" json:"t"`
 	Cloid      string        `msgpack:"c,omitempty" json:"c,omitempty"`
 }
+type ModifyResponse struct {
+	Status   string                  `json:"status"`
+	Response PlaceOrderInnerResponse `json:"response"`
+}
+type ModifyOrderWire struct {
+	OrderId int       `msgpack:"oid" json:"oid"`
+	Order   OrderWire `msgpack:"order" json:"order"`
+}
+type ModifyOrderAction struct {
+	Type     string            `msgpack:"type" json:"type"`
+	Modifies []ModifyOrderWire `msgpack:"modifies" json:"modifies"`
+}
+
+type ModifyOrderRequest struct {
+	OrderId    int       `json:"oid"`
+	Coin       string    `json:"coin"`
+	IsBuy      bool      `json:"is_buy"`
+	Sz         float64   `json:"sz"`
+	LimitPx    float64   `json:"limit_px"`
+	OrderType  OrderType `json:"order_type"`
+	ReduceOnly bool      `json:"reduce_only"`
+	Cloid      string    `json:"cloid,omitempty"`
+}
 
 type OrderTypeWire struct {
 	Limit   *LimitOrderType   `json:"limit,omitempty" msgpack:"limit,omitempty"`


### PR DESCRIPTION
Add `BulkModifyOrders` method and `exchange_type.go` structs to modify orders. 