### PR TITLE
Patch ModifyOrderRequestToWire

### DIFF
--- a/hyperliquid/convert.go
+++ b/hyperliquid/convert.go
@@ -62,15 +62,25 @@ func OrderRequestToWire(req OrderRequest, meta map[string]AssetInfo, isSpot bool
 		OrderType:  OrderTypeToWire(req.OrderType),
 	}
 }
-func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo) ModifyOrderWire {
+
+func ModifyOrderRequestToWire(req ModifyOrderRequest, meta map[string]AssetInfo, isSpot bool) ModifyOrderWire {
 	info := meta[req.Coin]
+	var assetId, maxDecimals int
+	if isSpot {
+		// https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/asset-ids
+		assetId = info.AssetId + 10000
+		maxDecimals = SPOT_MAX_DECIMALS
+	} else {
+		assetId = info.AssetId
+		maxDecimals = PERP_MAX_DECIMALS
+	}
 	return ModifyOrderWire{
 		OrderId: req.OrderId,
 		Order: OrderWire{
-			Asset:      info.AssetId,
+			Asset:      assetId,
 			IsBuy:      req.IsBuy,
-			LimitPx:    FloatToWire(req.LimitPx, nil),
-			SizePx:     FloatToWire(req.Sz, &info.SzDecimals),
+			LimitPx:    FloatToWire(req.LimitPx, maxDecimals, info.SzDecimals),
+			SizePx:     FloatToWire(req.Sz, maxDecimals, info.SzDecimals),
 			ReduceOnly: req.ReduceOnly,
 			OrderType:  OrderTypeToWire(req.OrderType),
 		},

--- a/hyperliquid/exchange_service.go
+++ b/hyperliquid/exchange_service.go
@@ -274,11 +274,11 @@ func (api *ExchangeAPI) BulkCancelOrders(cancels []CancelOidWire) (*CancelOrderR
 
 // Bulk modify orders
 // https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#modify-multiple-orders
-func (api *ExchangeAPI) BulkModifyOrders(modifyRequests []ModifyOrderRequest) (*PlaceOrderResponse, error) {
+func (api *ExchangeAPI) BulkModifyOrders(modifyRequests []ModifyOrderRequest, isSpot bool) (*PlaceOrderResponse, error) {
 	wires := []ModifyOrderWire{}
 
 	for _, req := range modifyRequests {
-		wires = append(wires, ModifyOrderRequestToWire(req, api.meta))
+		wires = append(wires, ModifyOrderRequestToWire(req, api.meta, isSpot))
 	}
 	action := ModifyOrderAction{
 		Type:     "batchModify",


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and testing of order modifications in the `hyperliquid` package. The most important changes include adding support for spot orders in the `ModifyOrderRequestToWire` function, updating the `BulkModifyOrders` method to handle spot orders, and adding a new test for modifying orders.

### Improvements to order modification functionality:

* [`hyperliquid/convert.go`](diffhunk://#diff-260332d6eebcb6d59ffa366d90b7d5a07f2c6fa57946c117122b18081b66037dL65-R83): Added support for spot orders in the `ModifyOrderRequestToWire` function by introducing an `isSpot` parameter and adjusting asset ID and decimal precision based on the order type.
* [`hyperliquid/exchange_service.go`](diffhunk://#diff-4156bb8cb3316509d3cd1f5273e7c5692af648384a27cf96a69264bf551c808aL277-R281): Updated the `BulkModifyOrders` method to accept an `isSpot` parameter and pass it to the `ModifyOrderRequestToWire` function.

### Additions to testing:

* [`hyperliquid/exchange_test.go`](diffhunk://#diff-151897214667feb151759751e94822f2543d6b94dbdf784dc62e802bf9aaed7eR204-R259): Added a new test function `TestExchangeAPI_TestModifyOrder` to verify the functionality of modifying orders, including placing a limit order, modifying it, and then canceling all orders.

### Minor changes:

* [`hyperliquid/exchange_test.go`](diffhunk://#diff-151897214667feb151759751e94822f2543d6b94dbdf784dc62e802bf9aaed7eR4): Added an import statement for the `log` package.