### PR TITLE
Add a test for quick-start

### DIFF
--- a/hyperliquid/hyperliquid_test.go
+++ b/hyperliquid/hyperliquid_test.go
@@ -7,7 +7,7 @@ import (
 
 func GetHyperliquidAPI() *Hyperliquid {
 	hl := NewHyperliquid(&HyperliquidClientConfig{
-		IsMainnet:      true,
+		IsMainnet:      false,
 		AccountAddress: os.Getenv("TEST_ADDRESS"),
 		PrivateKey:     os.Getenv("TEST_PRIVATE_KEY"),
 	})
@@ -104,4 +104,13 @@ func TestHyperliquid_MakeSomeTradingLogic(t *testing.T) {
 		t.Errorf("Error: %v", err)
 	}
 	t.Logf("GetAccountState(): %v", res8)
+}
+
+func TestHyperliquid_MakeOrder(t *testing.T) {
+	client := GetHyperliquidAPI()
+	order, err := client.MarketOrder("ADA", 15, nil)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	t.Logf("MarketOrder(ADA, 15, nil): %+v", order)
 }


### PR DESCRIPTION
This pull request includes changes to the `hyperliquid/hyperliquid_test.go` file to modify the configuration and add a new test function. The most important changes include updating the `IsMainnet` configuration and adding a new test for placing a market order.

Configuration changes:

* [`hyperliquid/hyperliquid_test.go`](diffhunk://#diff-bbb839b61c41f29d957ed93c9bab7bf6e360ff9bd033128a4e8d305683507cc9L10-R10): Changed the `IsMainnet` configuration from `true` to `false` in the `GetHyperliquidAPI` function.

New test function:

* [`hyperliquid/hyperliquid_test.go`](diffhunk://#diff-bbb839b61c41f29d957ed93c9bab7bf6e360ff9bd033128a4e8d305683507cc9R108-R116): Added a new test function `TestHyperliquid_MakeOrder` to test the `MarketOrder` method with the parameters "ADA" and 15.