### PR TITLE
Exchange API: Add Cloid Support for Order Placing and Cancellation

### DIFF
--- a/hyperliquid/consts.go
+++ b/hyperliquid/consts.go
@@ -1,6 +1,6 @@
 package hyperliquid
 
-const GLOBAL_DEBUG = false // Defualt debug that is used in all tests
+const GLOBAL_DEBUG = false // Default debug that is used in all tests
 
 // Execution constants
 const DEFAULT_SLIPPAGE = 0.005 // 0.5% default slippage

--- a/hyperliquid/convert.go
+++ b/hyperliquid/convert.go
@@ -60,6 +60,7 @@ func OrderRequestToWire(req OrderRequest, meta map[string]AssetInfo, isSpot bool
 		SizePx:     FloatToWire(req.Sz, maxDecimals, info.SzDecimals),
 		ReduceOnly: req.ReduceOnly,
 		OrderType:  OrderTypeToWire(req.OrderType),
+		Cloid:      req.Cloid,
 	}
 }
 

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -28,6 +28,7 @@ type OrderRequest struct {
 	LimitPx    float64   `json:"limit_px"`
 	OrderType  OrderType `json:"order_type"`
 	ReduceOnly bool      `json:"reduce_only"`
+	Cloid      string    `json:"cloid,omitempty"`
 }
 
 type OrderType struct {
@@ -160,7 +161,8 @@ type CancelResponseStatuses struct {
 }
 
 type RestingStatus struct {
-	OrderId int `json:"oid"`
+	OrderId int    `json:"oid"`
+	Cloid   string `json:"cloid,omitempty"`
 }
 
 type CloseRequest struct {
@@ -175,6 +177,7 @@ type FilledStatus struct {
 	OrderId int     `json:"oid"`
 	AvgPx   float64 `json:"avgPx,string"`
 	TotalSz float64 `json:"totalSz,string"`
+	Cloid   string  `json:"cloid,omitempty"`
 }
 
 type Liquidation struct {

--- a/hyperliquid/exchange_types.go
+++ b/hyperliquid/exchange_types.go
@@ -146,6 +146,16 @@ type CancelOidWire struct {
 	Oid   int `msgpack:"o" json:"o"`
 }
 
+type CancelCloidWire struct {
+	Asset int    `msgpack:"asset" json:"asset"`
+	Cloid string `msgpack:"cloid" json:"cloid"`
+}
+
+type CancelCloidOrderAction struct {
+	Type    string            `msgpack:"type" json:"type"`
+	Cancels []CancelCloidWire `msgpack:"cancels" json:"cancels"`
+}
+
 type CancelOrderResponse struct {
 	Status   string              `json:"status"`
 	Response InnerCancelResponse `json:"response"`

--- a/hyperliquid/hyperliquid_test.go
+++ b/hyperliquid/hyperliquid_test.go
@@ -70,38 +70,46 @@ func TestHyperliquid_MakeSomeTradingLogic(t *testing.T) {
 	}
 	t.Logf("LimitOrder(TifGtc, ETH, -0.01, 5000.1, true): %v", res3)
 
+	res4, err := client.LimitOrder(TifGtc, "ETH", 0.01, 1234.1, false, "0x1234567890abcdef1234567890abcdef")
+	if err != nil {
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+	}
+	t.Logf("LimitOrder(TifIoc, ETH, 0.01, 1234.1, false, 0x1234567890abcdef1234567890abcdef): %v", res4)
+
 	// Get all ordres
-	res4, err := client.GetAccountOpenOrders()
+	res5, err := client.GetAccountOpenOrders()
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	t.Logf("GetAccountOpenOrders(): %v", res4)
+	t.Logf("GetAccountOpenOrders(): %v", res5)
 
 	// Close all orders
-	res5, err := client.CancelAllOrders()
+	res6, err := client.CancelAllOrders()
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	t.Logf("CancelAllOrders(): %v", res5)
+	t.Logf("CancelAllOrders(): %v", res6)
 
 	// Make market order
-	res6, err := client.MarketOrder("ETH", 0.01, nil)
+	res7, err := client.MarketOrder("ETH", 0.01, nil)
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	t.Logf("MarketOrder(ETH, 0.01, nil): %v", res6)
+	t.Logf("MarketOrder(ETH, 0.01, nil): %v", res7)
 
 	// Close position
-	res7, err := client.ClosePosition("ETH")
+	res8, err := client.ClosePosition("ETH")
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	t.Logf("ClosePosition(ETH): %v", res7)
+	t.Logf("ClosePosition(ETH): %v", res8)
 
 	// Get account balance
-	res8, err := client.GetAccountState()
+	res9, err := client.GetAccountState()
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	t.Logf("GetAccountState(): %v", res8)
+	t.Logf("GetAccountState(): %v", res9)
 }


### PR DESCRIPTION
* Added `Cloid` parameter to `LimitOrder` and `MarketOrder` functions.
* Added `CancelOrderByCloid()` method to cancel orders by client order id.
* Added test coverage for placing limit orders with client order id.
* Fixed minor typo in `consts.go`.